### PR TITLE
removed trailing comma for $.ajax data argument

### DIFF
--- a/ajax.sublime-snippet
+++ b/ajax.sublime-snippet
@@ -3,7 +3,7 @@
 	url: '${1:/path/to/file}',
 	${2:type: '${3:default GET (Other values: POST)}',}
 	${4:dataType: '${5:default: Intelligent Guess (Other values: xml, json, script, or html)}',}
-	${6:data: {param1: 'value1'\},}
+	${6:data: {param1: 'value1'\}}
 })
 ${7:.done(function() {
 	console.log("success");


### PR DESCRIPTION
When the $.ajax command auto-completes, there is a trailing comma on the data parameter object.  If left in the code, it will cause issues with IE8 (and below).  I'm removing the comma so other's won't forget to remove it.
