### PR TITLE
fixed incompatibility with users not using JavaScript Ultimate

### DIFF
--- a/Syntaxes/jQueryJavaScript.tmLanguage
+++ b/Syntaxes/jQueryJavaScript.tmLanguage
@@ -118,6 +118,10 @@
 					<key>include</key>
 					<string>source.js.dom</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.js</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -216,6 +220,10 @@
 					<key>include</key>
 					<string>source.js.dom</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.js</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -309,6 +317,10 @@
 				<dict>
 					<key>include</key>
 					<string>source.js.dom</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.js</string>
 				</dict>
 			</array>
 		</dict>
@@ -404,6 +416,10 @@
 					<key>include</key>
 					<string>source.js.dom</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.js</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -459,6 +475,10 @@
 		<dict>
 			<key>include</key>
 			<string>source.js.dom</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>source.js</string>
 		</dict>
 	</array>
 	<key>repository</key>
@@ -588,6 +608,10 @@
 				<dict>
 					<key>include</key>
 					<string>source.js.dom</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.js</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
I'm not sure where I went wrong when I tested [SublimeText jQuery](https://github.com/SublimeText/jQuery) with [JavaScript Ultimate](https://github.com/JoshuaWise/javascript-ultimate), but this commit will fix the undesired [dependancy problem](https://github.com/SublimeText/jQuery/issues/22).